### PR TITLE
Fix: Promote project's standards to `C++17`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.2)
 
 project(vera CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
-add_compile_options(-DGLM_FORCE_CXX11)
+add_compile_options(-DGLM_FORCE_CXX17)
 
 if (NO_X11 OR FORCE_GBM)
-    add_compile_options(-std=c++11 -fpermissive -Wno-psabi)
+    add_compile_options(-std=c++17 -fpermissive -Wno-psabi)
 endif()
 
 # The compiled library code is here


### PR DESCRIPTION
* As titled. :tada: 
* Many greater benefits compared to `C++11`, especially to do with `constexpr`, lambdas, and standard algorithms.
* This gives developers tools to refactor the codebase and to express intent of code, in a much more simple way, (with a focus) to other developers reading the project's code.