### PR TITLE
Fix TextureCube destructor

### DIFF
--- a/src/gl/textureCube.cpp
+++ b/src/gl/textureCube.cpp
@@ -18,7 +18,6 @@ TextureCube::TextureCube()
 }
 
 TextureCube::~TextureCube() {
-    glDeleteTextures(1, &m_id);
 }
 
 bool TextureCube::load(const std::string &_path, bool _vFlip) {


### PR DESCRIPTION
Just use baseclass constructor, which has the test for `m_id != 0`. See [texture.cpp:14](https://github.com/patriciogonzalezvivo/vera/blob/main/src/gl/texture.cpp#L14)

Fixes https://github.com/patriciogonzalezvivo/glslViewer/issues/291