### PR TITLE
fix REVERT_TO_PREVIOUS_SHADER by introducing previousSource variables

### DIFF
--- a/include/vera/gl/shader.h
+++ b/include/vera/gl/shader.h
@@ -33,7 +33,7 @@ public:
 
     bool    load(const std::string& _fragmentSrc, const std::string& _vertexSrc, ShaderErrorResolve _onError = SHOW_MAGENTA_SHADER, bool _verbose = false);
     void    use();
-    
+
     const   GLuint  getProgram() const { return m_program; };
     const   GLuint  getFragmentShader() const { return m_fragmentShader; };
     const   GLuint  getVertexShader() const { return m_vertexShader; };
@@ -45,7 +45,7 @@ public:
     bool    inUse() const;
     bool    isDirty() const { return m_program == 0 || m_needsReloading || m_defineChange; }
     bool    isLoaded() const;
-   
+
     void    setUniform(const std::string& _name, int _x);
     void    setUniform(const std::string& _name, int _x, int _y);
     void    setUniform(const std::string& _name, int _x, int _y, int _z);
@@ -92,7 +92,10 @@ protected:
     std::string m_defineStack;
     std::string m_fragmentSource;
     std::string m_vertexSource;
-    
+
+    std::string m_previousFragmentSource;
+    std::string m_previousVertexSource;
+
     GLuint      m_program;
     GLuint      m_fragmentShader;
     GLuint      m_vertexShader;


### PR DESCRIPTION
The Problem: glslViewer is using `setSource()` and `use()` to render the canvas shader (and possibly others).
The first overwrites the `m_fragmentSource` field and the latter calls `load()` with the (new) `m_fragmentSource`.
However, `load()` assumes the passed source is new and reverts to the local `m_fragmentSource` if it fails compilation - which also fails since it is the same and always results in the `SHOW_MAGENTA_SHADER` behaviour.

To fix this, the successfully compiled shader sources are stored in the `m_previousFragmentSource` and `m_previousVertexSource`. In the worst case this doubles the memory required to save the shader source, but it should be negligible and can be disabled by setting the error handling to `DONT_KEEP_SHADER`.

Tested with the latest glslViewer https://github.com/patriciogonzalezvivo/glslViewer/commit/b17ee73091a3890ecc152fc85c8c2bdaeba92483 - don't forget to set `error_screen,off` when testing like I did :sweat_smile: 