### PR TITLE
Bug revert to previous shader not working

### DIFF
--- a/include/vera/gl/shader.h
+++ b/include/vera/gl/shader.h
@@ -33,7 +33,7 @@ public:
 
     bool    load(const std::string& _fragmentSrc, const std::string& _vertexSrc, ShaderErrorResolve _onError = SHOW_MAGENTA_SHADER, bool _verbose = false);
     void    use();
-    
+
     const   GLuint  getProgram() const { return m_program; };
     const   GLuint  getFragmentShader() const { return m_fragmentShader; };
     const   GLuint  getVertexShader() const { return m_vertexShader; };
@@ -45,7 +45,7 @@ public:
     bool    inUse() const;
     bool    isDirty() const { return m_program == 0 || m_needsReloading || m_defineChange; }
     bool    isLoaded() const;
-   
+
     void    setUniform(const std::string& _name, int _x);
     void    setUniform(const std::string& _name, int _x, int _y);
     void    setUniform(const std::string& _name, int _x, int _y, int _z);
@@ -92,7 +92,10 @@ protected:
     std::string m_defineStack;
     std::string m_fragmentSource;
     std::string m_vertexSource;
-    
+
+    std::string m_previousFragmentSource;
+    std::string m_previousVertexSource;
+
     GLuint      m_program;
     GLuint      m_fragmentShader;
     GLuint      m_vertexShader;

--- a/src/gl/shader.cpp
+++ b/src/gl/shader.cpp
@@ -28,7 +28,7 @@ Shader::Shader():
 
     #elif defined(_WIN32)
     addDefine("PLATFORM_WIN");
-    
+
     #elif defined(PLATFORM_RPI)
     addDefine("PLATFORM_RPI");
 
@@ -37,10 +37,10 @@ Shader::Shader():
 
     if (getXR() != NONE_XR_MODE)
         addDefine("PLATFORM_WEBXR", toString((int)getXR()));
-    
+
     #else
     addDefine("PLATFORM_LINUX");
-    
+
     #endif
 
     m_defineChange = true;
@@ -67,10 +67,11 @@ void Shader::setSource(const std::string& _fragmentSrc, const std::string& _vert
 
 bool Shader::load(const std::string& _fragmentSrc, const std::string& _vertexSrc, ShaderErrorResolve _onError, bool _verbose) {
     setVersionFromCode(_fragmentSrc);
-    if (m_fragmentSource == "" || m_vertexSource =="") {
+    if (m_fragmentSource == "" || m_vertexSource == "") {
         m_fragmentSource = getDefaultSrc(FRAG_ERROR);
         m_vertexSource = getDefaultSrc(VERT_ERROR);
     }
+
 
     // VERTEX
     m_vertexShader = compileShader(_vertexSrc, GL_VERTEX_SHADER, _verbose);
@@ -116,11 +117,11 @@ bool Shader::load(const std::string& _fragmentSrc, const std::string& _vertexSrc
 
     // SUCCESS
     if (_onError != DONT_KEEP_SHADER) {
-        // if setSource() and use() are used, the previous shader is lost and we need to explicitely remember it or REVERT_TO_PREVIOUS_SHADER always falls through to SHOW_MAGENTA_SHADER.
-        m_previousFragmentSource = m_fragmentSource;
-        m_previousVertexSource = m_vertexSource;
+        // we need to explicitely remember the previous shader or REVERT_TO_PREVIOUS_SHADER always falls through to SHOW_MAGENTA_SHADER.
         m_fragmentSource = _fragmentSrc;
         m_vertexSource = _vertexSrc;
+        m_previousFragmentSource = _fragmentSrc;
+        m_previousVertexSource = _vertexSrc;
     }
 
     GLint isLinked;
@@ -151,7 +152,7 @@ bool Shader::load(const std::string& _fragmentSrc, const std::string& _vertexSrc
         glDeleteProgram(m_program);
         load(getDefaultSrc(FRAG_ERROR), getDefaultSrc(VERT_ERROR), DONT_KEEP_SHADER, _verbose);
         return false;
-    } 
+    }
     else {
         glDeleteShader(m_vertexShader);
         glDeleteShader(m_fragmentShader);
@@ -293,7 +294,7 @@ GLuint Shader::compileShader(const std::string& _src, GLenum _type, bool _verbos
 
     GLint infoLength = 0;
     glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLength);
-    
+
 #if defined(PLATFORM_RPI) || defined(__EMSCRIPTEN__)
     if (infoLength > 1 && !isCompiled) {
 #else


### PR DESCRIPTION
This fixes issue #6 

By adding `m_previous{Fragment,Vertex}ShaderSource` that is only set if both compile successfully, we have access to the last working shader. We only store this when error handling is set to anything but `DONT_KEEP_SHADER`. This allows setting `m_{fragment,vertex}ShaderSource` through `setSource()`, independently of `load()`, as it is used in glslViewer. If load is called directly, the passed sources are used, keeping the intended behaviour of all functions.

The previous pull request messed up the order of storing the shader sources and accidentally stored a non-working shader. (around line 123 in latest pull request file)

Tested with latest glslViewer (`-e 'error_screen,off'`). Introducing an error in the shader keeps the last working configuration. Drag+dropping an incorrect shader also keeps the last working shader. In both cases fixing the error and updateing the file (or dropping the fixed shader) correctly updates the shaders shown.