### PR TITLE
Fix depth map segmentation fault

### DIFF
--- a/deps/phonedepth/extract_depthmap.cpp
+++ b/deps/phonedepth/extract_depthmap.cpp
@@ -748,23 +748,33 @@ int extract_depth(const char *filename,
     const unsigned char *extra = NULL;
     size_t extra_size = 0;
     image_type_t extra_type = TYPE_NONE;
+    const unsigned char* temp_dm = NULL;
 
     // look for the Samsung data
-    if (parse_samsung_trailer(file_data, file_size, cv, cv_size, dm, dm_size,
+    if (parse_samsung_trailer(file_data, file_size, cv, cv_size, &temp_dm, dm_size,
                                 &dm_width, &dm_height, dm_type, &orientation)) {
         std::cout << "Samsung trailer depth data founded" << std::endl;
         data_found = 1;
     } 
-    else if (parse_huawei_trailer(file_data, file_size, cv, cv_size, dm, dm_size,
+    else if (parse_huawei_trailer(file_data, file_size, cv, cv_size, &temp_dm, dm_size,
                                   &dm_width, &dm_height, dm_type, &orientation)) {
         std::cout << "Huawei trailer detph data founded" << std::endl;
         data_found = 1;
     }
-    else if (parse_apple_trailer( trailer, cv, cv_size, dm, dm_size,
+    else if (parse_apple_trailer( trailer, cv, cv_size, &temp_dm, dm_size,
                                   dm_type, &extra, &extra_size, &extra_type)) {
         std::cout << "Apple depth data founded" << std::endl;
         data_found = 1;
     }
+
+    unsigned char* buffer = (unsigned char*)malloc(*dm_size);
+
+    if (buffer == NULL) {
+        return 0;
+    }
+
+    *dm = buffer;
+    memcpy((void *)(*dm), temp_dm, *dm_size);
 
     // TODO: LG seems to work similar to Apple. they also concatenate JPEGs for color views,
     //       but then have a depth map in raw format it seems.

--- a/src/ops/pixel.cpp
+++ b/src/ops/pixel.cpp
@@ -84,9 +84,9 @@ unsigned char* loadPixelsDepth(const std::string& _path, int *_width, int *_heig
                         &dm, &dm_size, &dm_type) == 1) {
 
         if (dm_type == TYPE_JPEG) {
-            unsigned char* result = loadPixels(dm, dm_size, _width, _height, RGB, _vFlip);
+            unsigned char* pixels_depth = loadPixels(dm, dm_size, _width, _height, RGB, _vFlip);
             free(reinterpret_cast<void*>(const_cast<unsigned char*>(dm)));
-            return result;
+            return pixels_depth;
         }
     }
 

--- a/src/ops/pixel.cpp
+++ b/src/ops/pixel.cpp
@@ -84,7 +84,9 @@ unsigned char* loadPixelsDepth(const std::string& _path, int *_width, int *_heig
                         &dm, &dm_size, &dm_type) == 1) {
 
         if (dm_type == TYPE_JPEG) {
-            return loadPixels(dm, dm_size, _width, _height, RGB, _vFlip);
+            unsigned char* result = loadPixels(dm, dm_size, _width, _height, RGB, _vFlip);
+            free(reinterpret_cast<void*>(const_cast<unsigned char*>(dm)));
+            return result;
         }
     }
 


### PR DESCRIPTION
## Issue
When I executed `glslViewer` and dragged a jpeg file into it, I encountered a segmentation fault.

## Root Cause
In `loadPixelsDepth` function, `dm` is come from `file_data` inside [extract_depthmap.cpp](https://github.com/patriciogonzalezvivo/vera/blob/main/deps/phonedepth/extract_depthmap.cpp), but the [`file_data` is freed immediately after `extract_depth` is finished](https://github.com/patriciogonzalezvivo/vera/blob/main/deps/phonedepth/extract_depthmap.cpp#L775). 
But the following `loadPixels` function would also access `dm`, so it runs into segmentation fault. 

```
unsigned char* loadPixelsDepth(const std::string& _path, int *_width, int *_height, bool _vFlip) {
    const unsigned char *cv = NULL, *dm = NULL;
    size_t cv_size = 0, dm_size = 0;
    image_type_t dm_type = TYPE_NONE;

    //  proceed to check if it have depth data
    if (extract_depth(  _path.c_str(), 
                        &cv, &cv_size,
                        &dm, &dm_size, &dm_type) == 1) {

        if (dm_type == TYPE_JPEG) {
            return loadPixels(dm, dm_size, _width, _height, RGB, _vFlip);
        }
    }

    return nullptr;
}

```

## My Solution
I allocate a piece of memory and copy the content of original `dm` to it, to make it usable outside `extract_depth`, and free it after `loadPixels` is done. 
Because `dm` is only existed in this function scope and not pass to outside, so I believe free it at the end of `loadPixelsDepth` is a safe option.

Please review if this fix is appropriate. Thanks!