### PR TITLE
Make sure we have a default device when there are devices

### DIFF
--- a/src/gl/textureStreamAudio.cpp
+++ b/src/gl/textureStreamAudio.cpp
@@ -83,6 +83,8 @@ bool TextureStreamAudio::load(const std::string &_device_id_str, bool _vFlip, ve
     }
 
     std::cout << "Capture devices available\n";
+    if (captureDeviceCount > 0)
+        default_device_id = 0;
     for (ma_uint32 iDevice = 0; iDevice < captureDeviceCount; ++iDevice) {
         if (pCaptureDeviceInfos[iDevice].isDefault == true)
             default_device_id = iDevice;


### PR DESCRIPTION
On OpenBSD, sndio is recognized by miniaudio, but contains exactly one device that is the microphone device, which isn't marked as the default device by miniaudio. To prevent this from happening, I think vera should use the first device found as the default, default device. Without this change, although there is a device available, glslViewer does not set the input audio device on OpenBSD.

Merry Christmas!